### PR TITLE
Fix compile error with MSVC

### DIFF
--- a/include/tao/json/internal/errors.hh
+++ b/include/tao/json/internal/errors.hh
@@ -30,24 +30,35 @@ namespace tao
             }
          };
 
-         template<> const std::string errors< rules::text >::error_message __attribute__(( weak )) = "no valid JSON";
+#if defined(_MSC_VER)
+#define WEAK_PREFIX __declspec(selectany)
+#define WEAK_SUFFIX
+#else
+#define WEAK_PREFIX
+#define WEAK_SUFFIX __attribute__(( weak ))
+#endif
 
-         template<> const std::string errors< rules::end_array >::error_message __attribute__(( weak )) = "incomplete array, expected ']'";
-         template<> const std::string errors< rules::end_object >::error_message __attribute__(( weak )) = "incomplete object, expected '}'";
-         template<> const std::string errors< rules::member >::error_message __attribute__(( weak )) = "expected member";
-         template<> const std::string errors< rules::name_separator >::error_message __attribute__(( weak )) = "expected ':'";
-         template<> const std::string errors< rules::array_element >::error_message __attribute__(( weak )) = "expected value";
-         template<> const std::string errors< rules::value >::error_message __attribute__(( weak )) = "expected value";
+         template<> WEAK_PREFIX const std::string errors< rules::text >::error_message WEAK_SUFFIX = "no valid JSON";
 
-         template<> const std::string errors< rules::edigits >::error_message __attribute__(( weak )) = "expected at least one exponent digit";
-         template<> const std::string errors< rules::fdigits >::error_message __attribute__(( weak )) = "expected at least one fraction digit";
-         template<> const std::string errors< rules::xdigit >::error_message __attribute__(( weak )) = "incomplete universal character name";
-         template<> const std::string errors< rules::escaped >::error_message __attribute__(( weak )) = "unknown escape sequence";
-         template<> const std::string errors< rules::chars >::error_message __attribute__(( weak )) = "invalid character in string";
-         template<> const std::string errors< rules::string::content >::error_message __attribute__(( weak )) = "unterminated string";
-         template<> const std::string errors< rules::key::content >::error_message __attribute__(( weak )) = "unterminated key";
+         template<> WEAK_PREFIX const std::string errors< rules::end_array >::error_message WEAK_SUFFIX = "incomplete array, expected ']'";
+         template<> WEAK_PREFIX const std::string errors< rules::end_object >::error_message WEAK_SUFFIX = "incomplete object, expected '}'";
+         template<> WEAK_PREFIX const std::string errors< rules::member >::error_message WEAK_SUFFIX = "expected member";
+         template<> WEAK_PREFIX const std::string errors< rules::name_separator >::error_message WEAK_SUFFIX = "expected ':'";
+         template<> WEAK_PREFIX const std::string errors< rules::array_element >::error_message WEAK_SUFFIX = "expected value";
+         template<> WEAK_PREFIX const std::string errors< rules::value >::error_message WEAK_SUFFIX = "expected value";
 
-         template<> const std::string errors< tao_json_pegtl::eof >::error_message __attribute__(( weak )) = "unexpected character after JSON value";
+         template<> WEAK_PREFIX const std::string errors< rules::edigits >::error_message WEAK_SUFFIX = "expected at least one exponent digit";
+         template<> WEAK_PREFIX const std::string errors< rules::fdigits >::error_message WEAK_SUFFIX = "expected at least one fraction digit";
+         template<> WEAK_PREFIX const std::string errors< rules::xdigit >::error_message WEAK_SUFFIX = "incomplete universal character name";
+         template<> WEAK_PREFIX const std::string errors< rules::escaped >::error_message WEAK_SUFFIX = "unknown escape sequence";
+         template<> WEAK_PREFIX const std::string errors< rules::chars >::error_message WEAK_SUFFIX = "invalid character in string";
+         template<> WEAK_PREFIX const std::string errors< rules::string::content >::error_message WEAK_SUFFIX = "unterminated string";
+         template<> WEAK_PREFIX const std::string errors< rules::key::content >::error_message WEAK_SUFFIX = "unterminated key";
+
+         template<> WEAK_PREFIX const std::string errors< tao_json_pegtl::eof >::error_message WEAK_SUFFIX = "unexpected character after JSON value";
+
+#undef WEAK_PREFIX
+#undef WEAK_SUFFIX
 
       } // internal
 


### PR DESCRIPTION
Hello,

I tried using your library in a project without realizing that it does not seem to support MSVC. My C++ skills are rusty enough that I'm out of my depth trying to make it work, but I did fix one issue and thought I'd pass it along.

MSVC does weak linkage differently GCC. The default behavior in MSVC does allow symbols to be replaced, but it does not merge symbols that are defined multiple times. For that you need _declspec(selectany).